### PR TITLE
[Registry] New Component and Contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ To get the diff between two versions, go to https://github.com/SonsOfPHP/sonsofp
 
 ## [Unreleased]
 
+* [PR #226](https://github.com/SonsOfPHP/sonsofphp/pull/226) [Registry] New Component and Contract
 * [PR #225](https://github.com/SonsOfPHP/sonsofphp/pull/225) Maintenance
 * [PR #222](https://github.com/SonsOfPHP/sonsofphp/pull/222) [Assert] New Component
 * [PR #221](https://github.com/SonsOfPHP/sonsofphp/pull/221) [StateMachine] New Contract and Component

--- a/bard.json
+++ b/bard.json
@@ -178,6 +178,14 @@
             "repository": "git@github.com:SonsOfPHP/pager-contract.git"
         },
         {
+            "path": "src/SonsOfPHP/Component/Registry",
+            "repository": "git@github.com:SonsOfPHP/registry.git"
+        },
+        {
+            "path": "src/SonsOfPHP/Contract/Registry",
+            "repository": "git@github.com:SonsOfPHP/registry-contract.git"
+        },
+        {
             "path": "src/SonsOfPHP/Contract/Version",
             "repository": "git@github.com:SonsOfPHP/version-contract.git"
         }

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "psr/http-server-middleware-implementation": "^1.0",
         "sonsofphp/http-handler-implementation": "0.3.x-dev",
         "sonsofphp/mailer-implementation": "0.3.x-dev",
-        "sonsofphp/state-machine-implementation": "0.3.x-dev"
+        "sonsofphp/state-machine-implementation": "0.3.x-dev",
+        "sonsofphp/registry-implementation": "0.3.x-dev"
     },
     "require": {
         "php": ">=8.2",
@@ -87,7 +88,8 @@
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "aws/aws-sdk-php": "^3.0",
-        "liip/imagine-bundle": "^2.0"
+        "liip/imagine-bundle": "^2.0",
+        "sonsofphp/registry-contract": "0.3.x-dev"
     },
     "replace": {
         "sonsofphp/bard": "self.version",
@@ -135,7 +137,9 @@
         "sonsofphp/filesystem-liip-imagine": "self.version",
         "sonsofphp/state-machine": "self.version",
         "sonsofphp/state-machine-contract": "self.version",
-        "sonsofphp/assert": "self.version"
+        "sonsofphp/assert": "self.version",
+        "sonsofphp/registry": "self.version",
+        "sonsofphp/registry-contract": "self.version"
     },
     "autoload": {
         "psr-4": {
@@ -183,6 +187,8 @@
             "SonsOfPHP\\Contract\\Logger\\": "src/SonsOfPHP/Contract/Logger",
             "SonsOfPHP\\Contract\\Money\\": "src/SonsOfPHP/Contract/Money",
             "SonsOfPHP\\Contract\\Pager\\": "src/SonsOfPHP/Contract/Pager",
+            "SonsOfPHP\\Component\\Registry\\": "src/SonsOfPHP/Component/Registry",
+            "SonsOfPHP\\Contract\\Registry\\": "src/SonsOfPHP/Contract/Registry",
             "SonsOfPHP\\Contract\\Version\\": "src/SonsOfPHP/Contract/Version"
         },
         "exclude-from-classmap": [
@@ -217,7 +223,8 @@
             "src/SonsOfPHP/Bridge/Doctrine/Collections/Pager/Tests",
             "src/SonsOfPHP/Bridge/Doctrine/DBAL/Pager/Tests",
             "src/SonsOfPHP/Bridge/Doctrine/ORM/Pager/Tests",
-            "src/SonsOfPHP/Component/Version/Tests"
+            "src/SonsOfPHP/Component/Version/Tests",
+            "src/SonsOfPHP/Component/Registry/Tests"
         ]
     },
     "extra": {

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -51,6 +51,7 @@
   * [Queries](components/money/queries.md)
 * [Pager](components/pager/README.md)
   * [Adapters](components/pager/adapters.md)
+* [Registry](components/registry.md)
 * [State Machine](components/state-machine.md)
 * [Version](components/version.md)
 
@@ -63,6 +64,7 @@
 * [Filesystem](contracts/filesystem.md)
 * [Mailer](contracts/mailer.md)
 * [Pager](contracts/pager.md)
+* [Registry](contracts/registry.md)
 * [State Machine](contracts/state-machine.md)
 
 ## 💁 Contributing

--- a/docs/components/registry.md
+++ b/docs/components/registry.md
@@ -1,0 +1,32 @@
+---
+title: Registry
+---
+
+## Installation
+
+```shell
+composer require sonsofphp/registry
+```
+
+## Usage
+
+```php
+<?php
+
+use SonsOfPHP\Component\Registry\ServiceRegistry;
+
+$registry = new ServiceRegistry($interfaceClassName);
+
+$registry->register('service.id', $service);
+$service = $registry->get('service.id');
+
+if ($registry->has('service.id')) {
+    // ...
+}
+
+$registry->unregister('service.id');
+
+foreach ($registry->all() as $identifier => $service) {
+    // ...
+}
+```

--- a/docs/contracts/registry.md
+++ b/docs/contracts/registry.md
@@ -1,0 +1,9 @@
+---
+title: Registry Contract
+---
+
+## Installation
+
+```shell
+composer require sonsofphp/registry-contract
+```

--- a/src/SonsOfPHP/Component/Registry/.gitattributes
+++ b/src/SonsOfPHP/Component/Registry/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/SonsOfPHP/Component/Registry/.gitignore
+++ b/src/SonsOfPHP/Component/Registry/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+phpunit.xml
+vendor/

--- a/src/SonsOfPHP/Component/Registry/Exception/ExistingServiceException.php
+++ b/src/SonsOfPHP/Component/Registry/Exception/ExistingServiceException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Registry\Exception;
+
+use SonsOfPHP\Contract\Registry\ExistingServiceExceptionInterface;
+
+/**
+ * @author Joshua Estes <joshua@sonsofphp.com>
+ */
+class ExistingServiceException extends \Exception implements ExistingServiceExceptionInterface {}

--- a/src/SonsOfPHP/Component/Registry/Exception/NonExistingServiceException.php
+++ b/src/SonsOfPHP/Component/Registry/Exception/NonExistingServiceException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Registry\Exception;
+
+use SonsOfPHP\Contract\Registry\NonExistingServiceExceptionInterface;
+
+/**
+ * @author Joshua Estes <joshua@sonsofphp.com>
+ */
+class NonExistingServiceException extends \Exception implements NonExistingServiceExceptionInterface {}

--- a/src/SonsOfPHP/Component/Registry/LICENSE
+++ b/src/SonsOfPHP/Component/Registry/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2022 to Present Joshua Estes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/SonsOfPHP/Component/Registry/README.md
+++ b/src/SonsOfPHP/Component/Registry/README.md
@@ -1,0 +1,52 @@
+Sons of PHP - State Machine
+===========================
+
+```php
+<?php
+
+use SonsOfPHP\Component\StateMachine\StateMachine;
+
+$sm = new StateMachine([
+    'graph' => 'order',
+    'supports' => [
+        OrderInterface::class,
+    ],
+    'transitions' => [
+        'create' => [
+            'from' => 'draft',
+            'to' => 'new',
+        ],
+        'fulfill' => [
+            'from' => 'new',
+            'to' => 'fulfilled',
+        ],
+        'cancel' => [
+            'from' => ['draft', 'new', 'fulfilled'],
+            'to' => 'fulfilled',
+        ],
+    ],
+]);
+
+// Check if state can change
+$sm->can($order, 'create');
+
+// Apply transition
+$sm->apply($order, 'fulfil');
+
+// Get Current State
+$sm->getState($order);
+```
+
+## Learn More
+
+* [Documentation][docs]
+* [Contributing][contributing]
+* [Report Issues][issues] and [Submit Pull Requests][pull-requests] in the [Mother Repository][mother-repo]
+* Get Help & Support using [Discussions][discussions]
+
+[discussions]: https://github.com/orgs/SonsOfPHP/discussions
+[mother-repo]: https://github.com/SonsOfPHP/sonsofphp
+[contributing]: https://docs.sonsofphp.com/contributing/
+[docs]: https://docs.sonsofphp.com/components/state-machine/
+[issues]: https://github.com/SonsOfPHP/sonsofphp/issues?q=is%3Aopen+is%3Aissue+label%3AStateMachine
+[pull-requests]: https://github.com/SonsOfPHP/sonsofphp/pulls?q=is%3Aopen+is%3Apr+label%3AStateMachine

--- a/src/SonsOfPHP/Component/Registry/ServiceRegistry.php
+++ b/src/SonsOfPHP/Component/Registry/ServiceRegistry.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Registry;
+
+use SonsOfPHP\Contract\Registry\ServiceRegistryInterface;
+use SonsOfPHP\Component\Registry\Exception\ExistingServiceException;
+use SonsOfPHP\Component\Registry\Exception\NonExistingServiceException;
+
+/**
+ * @author Joshua Estes <joshua@sonsofphp.com>
+ */
+class ServiceRegistry implements ServiceRegistryInterface
+{
+    private array $services = [];
+
+    public function __construct(
+        private string $interface,
+    ) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all(): iterable
+    {
+        return $this->services;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register(string $identifier, object $service): void
+    {
+        if ($this->has($identifier)) {
+            throw new ExistingServiceException();
+        }
+
+        if (!$service instanceof $this->interface) {
+            throw new \InvalidArgumentException();
+        }
+
+        $this->services[$identifier] = $service;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unregister(string $identifier): void
+    {
+        if (!$this->has($identifier)) {
+            throw new NonExistingServiceException();
+        }
+
+        unset($this->services[$identifier]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has(string $identifier): bool
+    {
+        return array_key_exists($identifier, $this->services);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(string $identifier): object
+    {
+        if (!$this->has($identifier)) {
+            throw new NonExistingServiceException();
+        }
+
+        return $this->services[$identifier];
+    }
+}

--- a/src/SonsOfPHP/Component/Registry/ServiceRegistry.php
+++ b/src/SonsOfPHP/Component/Registry/ServiceRegistry.php
@@ -33,11 +33,15 @@ class ServiceRegistry implements ServiceRegistryInterface
     public function register(string $identifier, object $service): void
     {
         if ($this->has($identifier)) {
-            throw new ExistingServiceException();
+            throw new ExistingServiceException(sprintf('Service "%s" already exists', $identifier));
         }
 
         if (!$service instanceof $this->interface) {
-            throw new \InvalidArgumentException();
+            throw new \InvalidArgumentException(sprintf(
+                'Wrong Service Type. Expected "%s" got "%s"',
+                $this->interface,
+                $service::class
+            ));
         }
 
         $this->services[$identifier] = $service;
@@ -49,7 +53,7 @@ class ServiceRegistry implements ServiceRegistryInterface
     public function unregister(string $identifier): void
     {
         if (!$this->has($identifier)) {
-            throw new NonExistingServiceException();
+            throw new NonExistingServiceException(sprintf('Service "%s" does not exist', $identifier));
         }
 
         unset($this->services[$identifier]);
@@ -69,7 +73,7 @@ class ServiceRegistry implements ServiceRegistryInterface
     public function get(string $identifier): object
     {
         if (!$this->has($identifier)) {
-            throw new NonExistingServiceException();
+            throw new NonExistingServiceException(sprintf('Service "%s" does not exist', $identifier));
         }
 
         return $this->services[$identifier];

--- a/src/SonsOfPHP/Component/Registry/Tests/ServiceRegistryTest.php
+++ b/src/SonsOfPHP/Component/Registry/Tests/ServiceRegistryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Component\Registry\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use SonsOfPHP\Component\Registry\ServiceRegistry;
+use SonsOfPHP\Contract\Registry\ServiceRegistryInterface;
+use SonsOfPHP\Contract\Registry\ExistingServiceExceptionInterface;
+use SonsOfPHP\Contract\Registry\NonExistingServiceExceptionInterface;
+
+#[CoversClass(ServiceRegistry::class)]
+final class ServiceRegistryTest extends TestCase
+{
+    private ServiceRegistry $registry;
+
+    protected function setUp(): void
+    {
+        $this->registry = new ServiceRegistry('Exception');
+    }
+
+    public function testItHasTheCorrectInterface(): void
+    {
+        $this->assertInstanceOf(ServiceRegistryInterface::class, $this->registry);
+    }
+
+    public function testItCanRegisterNewServices(): void
+    {
+        $identifier = 'exception';
+        $this->assertCount(0, $this->registry->all());
+        $this->assertFalse($this->registry->has($identifier));
+        $this->registry->register($identifier, new \Exception());
+        $this->assertCount(1, $this->registry->all());
+        $this->assertTrue($this->registry->has($identifier));
+    }
+
+    public function testItWillThrowCorrectExceptionWhenServiceIdentifierExists(): void
+    {
+        $this->registry->register('exception', new \Exception());
+        $this->expectException(ExistingServiceExceptionInterface::class);
+        $this->registry->register('exception', new \Exception());
+    }
+
+    public function testItWillThrowCorrectExceptionWhenServiceIsWrongType(): void
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->registry->register('stdclass', new \stdClass());
+    }
+
+    public function testItWillReturnAllServicesInTheCorrectFormat(): void
+    {
+        $this->registry->register('exception', new \Exception());
+        $services = $this->registry->all();
+        $this->assertArrayHasKey('exception', $services);
+    }
+
+    public function testItCanUnregisterServices(): void
+    {
+        $identifier = 'exception';
+        $this->registry->register($identifier, new \Exception());
+        $this->assertTrue($this->registry->has($identifier));
+        $this->registry->unregister($identifier);
+        $this->assertFalse($this->registry->has($identifier));
+    }
+
+    public function testItWillThrowCorrectExceptionWhenUnregisteringNonExistingService(): void
+    {
+        $this->expectException(NonExistingServiceExceptionInterface::class);
+        $this->registry->unregister('stdclass');
+    }
+
+    public function testItIsAbleToRetrieveRegisteredService(): void
+    {
+        $identifier = 'exception';
+        $service    = new \Exception();
+        $this->registry->register($identifier, $service);
+        $this->assertSame($service, $this->registry->get($identifier));
+    }
+
+    public function testItWillThrowCorrectExceptionWhenGettingNonExistingService(): void
+    {
+        $this->expectException(NonExistingServiceExceptionInterface::class);
+        $this->registry->get('stdclass');
+    }
+}

--- a/src/SonsOfPHP/Component/Registry/composer.json
+++ b/src/SonsOfPHP/Component/Registry/composer.json
@@ -1,18 +1,12 @@
 {
-    "name": "sonsofphp/registry-contract",
+    "name": "sonsofphp/registry",
     "type": "library",
-    "description": "Registry Contracts",
+    "description": "",
     "keywords": [
-        "abstractions",
-        "contracts",
-        "decoupling",
-        "interfaces",
-        "interoperability",
-        "standards",
         "service-registry",
         "registry"
     ],
-    "homepage": "https://github.com/SonsOfPHP/registry-contract",
+    "homepage": "https://github.com/SonsOfPHP/registry",
     "license": "MIT",
     "authors": [
         {
@@ -27,13 +21,20 @@
     },
     "autoload": {
         "psr-4": {
-            "SonsOfPHP\\Contract\\Registry\\": ""
-        }
+            "SonsOfPHP\\Component\\Registry\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.2"
+        "php": ">=8.2",
+        "sonsofphp/registry-contract": "0.3.x-dev"
+    },
+    "provide": {
+        "sonsofphp/registry-implementation": "0.3.x-dev"
     },
     "extra": {
         "sort-packages": true,

--- a/src/SonsOfPHP/Contract/Registry/.gitattributes
+++ b/src/SonsOfPHP/Contract/Registry/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/SonsOfPHP/Contract/Registry/.gitignore
+++ b/src/SonsOfPHP/Contract/Registry/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/

--- a/src/SonsOfPHP/Contract/Registry/ExistingServiceExceptionInterface.php
+++ b/src/SonsOfPHP/Contract/Registry/ExistingServiceExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Contract\Registry;
+
+/**
+ * @author Joshua Estes <joshua@sonsofphp.com>
+ */
+interface ExistingServiceExceptionInterface extends \Throwable {}

--- a/src/SonsOfPHP/Contract/Registry/LICENSE
+++ b/src/SonsOfPHP/Contract/Registry/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2022 to Present Joshua Estes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/SonsOfPHP/Contract/Registry/NonExistingServiceExceptionInterface.php
+++ b/src/SonsOfPHP/Contract/Registry/NonExistingServiceExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Contract\Registry;
+
+/**
+ * @author Joshua Estes <joshua@sonsofphp.com>
+ */
+interface NonExistingServiceExceptionInterface extends \Throwable {}

--- a/src/SonsOfPHP/Contract/Registry/PrioritizedServiceRegistryInterface.php
+++ b/src/SonsOfPHP/Contract/Registry/PrioritizedServiceRegistryInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Contract\Registry;
+
+/**
+ * @author Joshua Estes <joshua@sonsofphp.com>
+ */
+interface PrioritizedServiceRegistryInterface
+{
+    /**
+     * Returns all the services registered
+     *   key = identifier
+     *   value = services
+     *
+     * The services MUST be order based on priorities
+     */
+    public function all(): iterable;
+
+    /**
+     * Priorities MUST be ordered from largest number to lowest number.
+     *
+     * The default priority MUST be 0
+     *
+     * @throws ExistingServiceExceptionInterface
+     * @throws \InvalidArgumentException
+     *   If the $service does not implement the service interface
+     */
+    public function register(string $identifier, object $service, int $priority = 0): void;
+
+    /**
+     * @throws NonExistingServiceExceptionInterface
+     */
+    public function unregister(string $identifier): void;
+
+    /**
+     * Returns true if service exists.
+     */
+    public function has(string $identifier): bool;
+
+    /**
+     * @throws NonExistingServiceExceptionInterface
+     */
+    public function get(string $identifier): iterable;
+}

--- a/src/SonsOfPHP/Contract/Registry/README.md
+++ b/src/SonsOfPHP/Contract/Registry/README.md
@@ -1,0 +1,16 @@
+Sons of PHP - Registry Contract
+===============================
+
+## Learn More
+
+* [Documentation][docs]
+* [Contributing][contributing]
+* [Report Issues][issues] and [Submit Pull Requests][pull-requests] in the [Mother Repository][mother-repo]
+* Get Help & Support using [Discussions][discussions]
+
+[discussions]: https://github.com/orgs/SonsOfPHP/discussions
+[mother-repo]: https://github.com/SonsOfPHP/sonsofphp
+[contributing]: https://docs.sonsofphp.com/contributing/
+[docs]: https://docs.sonsofphp.com/contracts/registry/
+[issues]: https://github.com/SonsOfPHP/sonsofphp/issues?q=is%3Aopen+is%3Aissue+label%3ARegistry
+[pull-requests]: https://github.com/SonsOfPHP/sonsofphp/pulls?q=is%3Aopen+is%3Apr+label%3ARegistry

--- a/src/SonsOfPHP/Contract/Registry/ServiceRegistryInterface.php
+++ b/src/SonsOfPHP/Contract/Registry/ServiceRegistryInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonsOfPHP\Contract\Registry;
+
+/**
+ * @author Joshua Estes <joshua@sonsofphp.com>
+ */
+interface ServiceRegistryInterface
+{
+    /**
+     * Returns all the services registered
+     *   key = identifier
+     *   value = service
+     */
+    public function all(): iterable;
+
+    /**
+     * @throws ExistingServiceExceptionInterface
+     * @throws \InvalidArgumentException
+     *   If the $service does not implement the service interface
+     */
+    public function register(string $identifier, object $service): void;
+
+    /**
+     * @throws NonExistingServiceExceptionInterface
+     */
+    public function unregister(string $identifier): void;
+
+    /**
+     * Returns true if service exists.
+     */
+    public function has(string $identifier): bool;
+
+    /**
+     * @throws NonExistingServiceExceptionInterface
+     */
+    public function get(string $identifier): object;
+}

--- a/src/SonsOfPHP/Contract/Registry/composer.json
+++ b/src/SonsOfPHP/Contract/Registry/composer.json
@@ -1,0 +1,54 @@
+{
+    "name": "sonsofphp/registry-contract",
+    "type": "library",
+    "description": "Registry Contracts",
+    "keywords": [
+        "abstractions",
+        "contracts",
+        "decoupling",
+        "interfaces",
+        "interoperability",
+        "standards",
+        "service-registry",
+        "registry"
+    ],
+    "homepage": "https://github.com/SonsOfPHP/registry-contract",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Joshua Estes",
+            "email": "joshua@sonsofphp.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/SonsOfPHP/sonsofphp/issues",
+        "forum": "https://github.com/orgs/SonsOfPHP/discussions",
+        "docs": "https://docs.sonsofphp.com"
+    },
+    "autoload": {
+        "psr-4": {
+            "SonsOfPHP\\Contract\\Registry\\": ""
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require": {
+        "php": ">=8.2"
+    },
+    "extra": {
+        "sort-packages": true,
+        "branch-alias": {
+            "dev-main": "0.3.x-dev"
+        }
+    },
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/JoshuaEstes"
+        },
+        {
+            "type": "tidelift",
+            "url": "https://tidelift.com/subscription/pkg/packagist-sonsofphp-sonsofphp"
+        }
+    ]
+}


### PR DESCRIPTION
## Description

This component allows developers to registry services based on an identifier.

Example:
```php
$registry = new Registry('stdClass');
$registry->register('example.identifier', new stdClass());
// Throws Exception
$registry->register('another.identifier', 'not an object and does not implement/extend stdClass');

$service = $registry->get('example.identifier');
```

## Checklist
- [x] Updated CHANGELOG files
- [x] Updated Documentation
- [x] Unit Tests Created
- [x] php-cs-fixer
