### PR TITLE
[EventDispatcher] Replace deprecated implicit nullable

### DIFF
--- a/src/SonsOfPHP/Component/EventDispatcher/EventDispatcher.php
+++ b/src/SonsOfPHP/Component/EventDispatcher/EventDispatcher.php
@@ -23,7 +23,7 @@ class EventDispatcher implements EventDispatcherInterface
      * @param string|null $eventName
      *   Is the event name is null, is will use the event's classname as the Event Name
      */
-    public function dispatch(object $event, string $eventName = null): object
+    public function dispatch(object $event, ?string $eventName = null): object
     {
         $eventName ??= $event::class;
 


### PR DESCRIPTION
## Description

 The current implementation includes an implicit nullable parameter, which is deprecated in PHP 8.4 and causing deprecation notices. This PR makes the implicit type explicit.

Note: I haven't updated the changelog for this minor change but can by request.

## Checklist
- [ ] Updated CHANGELOG files
- [ ] Updated Documentation
- [ ] Unit Tests Created
- [X] php-cs-fixer
